### PR TITLE
fix: make Provider name unique

### DIFF
--- a/node/components/aws/CloudfrontWebsite.ts
+++ b/node/components/aws/CloudfrontWebsite.ts
@@ -38,7 +38,8 @@ export class CloudfrontWebsite extends pulumi.ComponentResource {
     super("aws-s3-cloudfront", name, {}, opts);
 
     // Define us-east-1 provider (required for CloudFront certificates)
-    const useast1 = new aws.Provider("useast1", { region: "us-east-1" });
+    // Provider name must be unique
+    const useast1 = new aws.Provider(`${args.targetDomain}-useast1`, { region: "us-east-1" });
 
     this.s3Bucket = args.s3Bucket;
     this.originAccessIdentity = args.originAccessIdentity;


### PR DESCRIPTION
"aws.Provider" requires a unique name otherwise instantiating the class more than once will cause a "Duplicate URN" error. Adding the targetDomain to the name value to make to avoid duplication. 