### PR TITLE
Ci/cloudfront update

### DIFF
--- a/node/components/aws/CloudfrontWebsite.ts
+++ b/node/components/aws/CloudfrontWebsite.ts
@@ -209,7 +209,7 @@ export class CloudfrontWebsite extends pulumi.ComponentResource {
     return this.cloudfrontDistribution.aliases;
   }
  
-  public cloudfrontARN(): pulumi.Output<string[] | undefined> {
+  public cloudfrontARN(): pulumi.Output<string | undefined> {
     return this.cloudfrontDistribution.arn;
   }
 }

--- a/node/components/aws/CloudfrontWebsite.ts
+++ b/node/components/aws/CloudfrontWebsite.ts
@@ -15,6 +15,8 @@ export interface CloudfrontWebsiteArgs {
   originAccessIdentity: aws.cloudfront.OriginAccessIdentity; // Origin Access Identity to access the private s3 bucket
 
   webAclId?: string | pulumi.Output<string>; // (Optional) Associate an existing WAF
+
+  lambdaRole?: string; // (Optional) Associate a lambda role with s3 bucket permissions
 }
 
 /**

--- a/node/components/aws/CloudfrontWebsite.ts
+++ b/node/components/aws/CloudfrontWebsite.ts
@@ -208,7 +208,7 @@ export class CloudfrontWebsite extends pulumi.ComponentResource {
   public cloudfrontAliases(): pulumi.Output<string[] | undefined> {
     return this.cloudfrontDistribution.aliases;
   }
- 
+
   public cloudfrontARN(): pulumi.Output<string | undefined> {
     return this.cloudfrontDistribution.arn;
   }

--- a/node/components/aws/CloudfrontWebsite.ts
+++ b/node/components/aws/CloudfrontWebsite.ts
@@ -212,8 +212,4 @@ export class CloudfrontWebsite extends pulumi.ComponentResource {
   public cloudfrontAliases(): pulumi.Output<string[] | undefined> {
     return this.cloudfrontDistribution.aliases;
   }
-
-  public cloudfrontARN(): pulumi.Output<string | undefined> {
-    return this.cloudfrontDistribution.arn;
-  }
 }

--- a/node/components/aws/CloudfrontWebsite.ts
+++ b/node/components/aws/CloudfrontWebsite.ts
@@ -208,4 +208,8 @@ export class CloudfrontWebsite extends pulumi.ComponentResource {
   public cloudfrontAliases(): pulumi.Output<string[] | undefined> {
     return this.cloudfrontDistribution.aliases;
   }
+ 
+  public cloudfrontARN(): pulumi.Output<string[] | undefined> {
+    return this.cloudfrontDistribution.arn;
+  }
 }

--- a/node/components/aws/CloudfrontWebsite.ts
+++ b/node/components/aws/CloudfrontWebsite.ts
@@ -16,7 +16,7 @@ export interface CloudfrontWebsiteArgs {
 
   webAclId?: string | pulumi.Output<string>; // (Optional) Associate an existing WAF
 
-  applyDefaultBucketPermission?: boolean | true;  // (Optional) Sometimes pulumi gets timing wrong if you want to apply another policy.  If omitted, the default policy will be created.
+  applyDefaultBucketPermission?: boolean | true; // (Optional) Sometimes pulumi gets timing wrong if you want to apply another policy.  If omitted, the default policy will be created.
 }
 
 /**
@@ -68,7 +68,7 @@ export class CloudfrontWebsite extends pulumi.ComponentResource {
         ),
       });
     }
-    
+
     // Cloudfront distribution
 
     // Get hosted zone

--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "AWS",
     "Azure"
   ],
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "GoSource Pulumi library for Node.js",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This PR allows the component to not create the default s3 bucket permission.  This should be skipped if you have another policy to be applied.

Pulumi on occasion gets the timing wrong, so this PR fixes that.